### PR TITLE
fix(modal): Remove modal body overflow property

### DIFF
--- a/packages/frosted-ui/components/ModalBody/ModalBody.tsx
+++ b/packages/frosted-ui/components/ModalBody/ModalBody.tsx
@@ -7,7 +7,7 @@ export type ModalBodyProps = {
 };
 
 export const ModalBody = ({ children }: ModalBodyProps) => (
-  <div className="overflow-y-auto px-6">{children}</div>
+  <div className="px-6">{children}</div>
 );
 
 ModalBody.displayName = 'ModalBody';


### PR DESCRIPTION
This PR removes the overflow property from the modal body. The parent element (Modal) already has an overflow property which allows scrolling and the correct styling. This property was causing the behavior as shown below:

Before:
<img width="746" alt="image" src="https://github.com/whopio/frosted-ui/assets/42128929/ba6f396d-fa83-41e6-8a11-c7a0d4ab2924">

After:
<img width="727" alt="image" src="https://github.com/whopio/frosted-ui/assets/42128929/8fbb70e6-b5a3-4389-a93c-026086fadae7">

Example issue reproduction: https://github.com/Wyatt-SG/frosted-ui-playground/blob/main/app/input-outline-issue/page.tsx