### PR TITLE
style: (storyboard) Removed unnecessary `overflow-scroll` from HorizontalTabList and PillTabList

### DIFF
--- a/packages/frosted-ui/src/components/HorizontalTabList/HorizontalTabList.tsx
+++ b/packages/frosted-ui/src/components/HorizontalTabList/HorizontalTabList.tsx
@@ -13,7 +13,7 @@ export const HorizontalTabList = ({
   return (
     <Tab.List
       className={cn(
-        'border-whop-stroke flex appearance-none items-center space-x-3 overflow-scroll border-b',
+        'border-whop-stroke flex appearance-none items-center space-x-3 border-b',
         className,
       )}
     >

--- a/packages/frosted-ui/src/components/PillTabList/PillTabList.tsx
+++ b/packages/frosted-ui/src/components/PillTabList/PillTabList.tsx
@@ -12,7 +12,7 @@ export const PillTabList = ({
   return (
     <Tab.List
       className={cn(
-        'bg-whop-hover flex h-10 appearance-none items-center overflow-scroll rounded-full p-1',
+        'bg-whop-hover flex h-10 appearance-none items-center rounded-full p-1',
         {
           'max-w-fit': !fullWidth,
         },


### PR DESCRIPTION
This PR removes `overflow-scroll` from these components `HorizontalTabList` & `PillTabList`

link: https://storybook.whop.com/?path=/docs/general-horizontaltabgroup--documentation
- Image shows **old** overflow style


![image](https://github.com/whopio/frosted-ui/assets/73144742/8ca6f9a6-45d4-4209-b4e8-d1d078889a36)

link: https://storybook.whop.com/?path=/docs/general-pilltabgroup--documentation
- Image shows **old** overflow style


![image](https://github.com/whopio/frosted-ui/assets/73144742/1cfd2c09-be2a-4f24-8297-0aaff43e0cbc)


