### PR TITLE
add legacy styles fallback

### DIFF
--- a/packages/frosted-ui/src/index.css
+++ b/packages/frosted-ui/src/index.css
@@ -56,6 +56,399 @@
     list-style: revert;
   }
 
+  .paragraph1 {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 19px;
+    line-height: 28px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .paragraph2 {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 24px;
+    letter-spacing: -0.015em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .paragraph3 {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 21px;
+    letter-spacing: -0.015em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .paragraph4 {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 17px;
+    letter-spacing: -0.015em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .text1 {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 16px;
+    line-height: 19px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .text2 {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 15px;
+    line-height: 18px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .text3 {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 17px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .text4 {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 13px;
+    line-height: 16px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .text5 {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 12px;
+    line-height: 15px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .text6 {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 11px;
+    line-height: 14px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .text7 {
+    font-style: normal;
+    font-weight: 400;
+    font-size: 10px;
+    line-height: 13px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .subtitle1 {
+    font-style: normal;
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 19px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .subtitle2 {
+    font-style: normal;
+    font-weight: 500;
+    font-size: 15px;
+    line-height: 18px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .subtitle3 {
+    font-style: normal;
+    font-weight: 500;
+    font-size: 14px;
+    line-height: 17px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .subtitle4 {
+    font-style: normal;
+    font-weight: 500;
+    font-size: 13px;
+    line-height: 16px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .subtitle5 {
+    font-style: normal;
+    font-weight: 500;
+    font-size: 12px;
+    line-height: 15px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .subtitle6 {
+    font-style: normal;
+    font-weight: 500;
+    font-size: 11px;
+    line-height: 14px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .subtitle7 {
+    font-style: normal;
+    font-weight: 500;
+    font-size: 10px;
+    line-height: 13px;
+    letter-spacing: -0.01em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .button1 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 17px;
+    line-height: 21px;
+    letter-spacing: -0.005em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .button2 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 16px;
+    line-height: 19px;
+    letter-spacing: -0.005em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .button3 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 15px;
+    line-height: 18px;
+    letter-spacing: -0.005em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .button4 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 17px;
+    letter-spacing: -0.005em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .button5 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 13px;
+    line-height: 16px;
+    letter-spacing: -0.005em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .overline1 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 17px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .overline2 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 13px;
+    line-height: 16px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .overline3 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 12px;
+    line-height: 15px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .overline4 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 11px;
+    line-height: 13px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .header1,
+  h1 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 40px;
+    line-height: 56px;
+    letter-spacing: -0.0125em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .header2,
+  h2 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 32px;
+    line-height: 45px;
+    letter-spacing: -0.0125em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .header3,
+  h3 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 24px;
+    line-height: 34px;
+    letter-spacing: -0.0125em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .header4,
+  h4 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 18px;
+    line-height: 25px;
+    letter-spacing: -0.0125em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .header5,
+  h5 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 16px;
+    line-height: 22px;
+    letter-spacing: -0.0125em;
+    font-family: var(--whopkit-font-sans), sans-serif;
+  }
+
+  .display1 {
+    font-style: normal;
+    font-weight: 700;
+    font-size: 40px;
+    line-height: 48px;
+    letter-spacing: 0em;
+    font-family: var(--whopkit-font-display), sans-serif;
+  }
+
+  .display2 {
+    font-style: normal;
+    font-weight: 700;
+    font-size: 32px;
+    line-height: 38px;
+    letter-spacing: 0em;
+    font-family: var(--whopkit-font-display), sans-serif;
+  }
+
+  .display3 {
+    font-style: normal;
+    font-weight: 700;
+    font-size: 24px;
+    line-height: 29px;
+    letter-spacing: 0em;
+    font-family: var(--whopkit-font-display), sans-serif;
+  }
+
+  .display4 {
+    font-style: normal;
+    font-weight: 700;
+    font-size: 18px;
+    line-height: 22px;
+    letter-spacing: 0em;
+    font-family: var(--whopkit-font-display), sans-serif;
+  }
+
+  .mono1 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 18px;
+    line-height: 21px;
+    letter-spacing: -0.01em;
+    text-transform: uppercase;
+    font-family: var(--whopkit-font-mono), monospace;
+  }
+
+  .mono2 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 16px;
+    line-height: 19px;
+    letter-spacing: -0.01em;
+    text-transform: uppercase;
+    font-family: var(--whopkit-font-mono), monospace;
+  }
+
+  .mono3 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 15px;
+    line-height: 18px;
+    letter-spacing: -0.01em;
+    text-transform: uppercase;
+    font-family: var(--whopkit-font-mono), monospace;
+  }
+
+  .mono4 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 16px;
+    letter-spacing: -0.01em;
+    text-transform: uppercase;
+    font-family: var(--whopkit-font-mono), monospace;
+  }
+
+  .mono5 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 13px;
+    line-height: 15px;
+    letter-spacing: -0.01em;
+    text-transform: uppercase;
+    font-family: var(--whopkit-font-mono), monospace;
+  }
+
+  .mono6 {
+    font-style: normal;
+    font-weight: 600;
+    font-size: 12px;
+    line-height: 14px;
+    letter-spacing: -0.01em;
+    text-transform: uppercase;
+    font-family: var(--whopkit-font-mono), monospace;
+  }
+
   /* Custom image styles */
 
   .ProseMirror img {


### PR DESCRIPTION
Apparently these styles were actually used in fe-monorepo.
At this point there's no point of trying to refactor it as we're working on a new version of Frosted.
So now I am adding them back.

Normally the text styles are used like so `<div className="text-subtitle3" />`. These styles are generated from the config in `font-sizes.ts`.

There are however instances in our fe-monorepo where the text elements were using hardcoded styles from `index.css` file and referenced by `<div className="subtitle3" />`