### PR TITLE
refactor: update avatar sizes to fix whop biz overrides

### DIFF
--- a/packages/frosted-ui/src/components/Avatar/Avatar.tsx
+++ b/packages/frosted-ui/src/components/Avatar/Avatar.tsx
@@ -125,13 +125,13 @@ export const Avatar = forwardRef(function Avatar<C extends ElementType = 'img'>(
   );
 
   const imageSize = cn({
-    'w-4 h-4': size === 16,
-    'w-6 h-6': size === 24,
-    'w-8 h-8': size === 32,
+    'w-[16px] h-[16px]': size === 16,
+    'w-[24px] h-[24px]': size === 24,
+    'w-[32px] h-[32px]': size === 32,
     'w-[40px] h-[40px]': size === 40,
-    'w-12 h-12': size === 48,
-    'w-14 h-14': size === 56,
-    'w-16 h-16': size === 64,
+    'w-[48px] h-[48px]': size === 48,
+    'w-[56px] h-[56px]': size === 56,
+    'w-[64px] h-[64px]': size === 64,
     'w-[72px] h-[72px]': size === 72,
     'w-[80px] h-[80px]': size === 80,
     'w-[128px] h-[128px]': size === 128,

--- a/packages/frosted-ui/src/components/Avatar/Avatar.tsx
+++ b/packages/frosted-ui/src/components/Avatar/Avatar.tsx
@@ -128,12 +128,12 @@ export const Avatar = forwardRef(function Avatar<C extends ElementType = 'img'>(
     'w-4 h-4': size === 16,
     'w-6 h-6': size === 24,
     'w-8 h-8': size === 32,
-    'w-10 h-10': size === 40,
+    'w-[40px] h-[40px]': size === 40,
     'w-12 h-12': size === 48,
     'w-14 h-14': size === 56,
     'w-16 h-16': size === 64,
     'w-[72px] h-[72px]': size === 72,
-    'w-20 h-20': size === 80,
+    'w-[80px] h-[80px]': size === 80,
     'w-[128px] h-[128px]': size === 128,
   });
 


### PR DESCRIPTION
For some reason on whop biz app we have overrides for the tailwind width utilities that convert them to their respective percent which causes the avatar not to display correct when it falls back this fixes it by update the overridden utilities with arbitrary values